### PR TITLE
Add zoom & pan to JSWindow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jswf/react",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Virtual Window for React",
   "main": "dist/index.js",
   "scripts": {

--- a/src/JSWindow/index.tsx
+++ b/src/JSWindow/index.tsx
@@ -452,6 +452,8 @@ export class JSWindow extends Component<WindowProps, State> {
           onMouseMove={this.onMouseMove.bind(this)}
         >
           <div ref={this.zoomRef} style={{
+            width: '100%',
+            height: '100%',
             transformOrigin: `${this.state.transformation.originX}px ${this.state.transformation.originY}px`,
             transform: `matrix(${this.state.transformation.scale}, 0, 0, ${this.state.transformation.scale}, ${this.state.transformation.translateX}, ${this.state.transformation.translateY})`,
           }}>

--- a/src/JSWindow/index.tsx
+++ b/src/JSWindow/index.tsx
@@ -141,8 +141,8 @@ export class JSWindow extends Component<WindowProps, State> {
       titleSize:
         (props.windowStyle! & WindowStyle.TITLE) === 0 ? 0 : props.titleSize!,
       borderSize: props.borderSize!,
-      x: props.x!,
-      y: props.y!,
+      x: props.x || 0,
+      y: props.y || 0,
       width: props.width!,
       height: props.height!,
       transformation: {
@@ -302,14 +302,10 @@ export class JSWindow extends Component<WindowProps, State> {
           y = this.state.y;
           if (x === null) {
             x = (parentWidth - width) / 2;
-          } else if (x < 0) x = 0;
-          else if (x + this.state.width > parentWidth)
-            x = parentWidth - this.state.width;
+          }
           if (y === null) {
             y = (parentHeight - height) / 2;
-          } else if (y < 0) y = 0;
-          else if (y + this.state.titleSize > parentHeight)
-            y = parentHeight - this.state.titleSize;
+          }
           clientWidth = this.state.width;
           clientHeight = 0;
 
@@ -323,12 +319,10 @@ export class JSWindow extends Component<WindowProps, State> {
           if (height > parentHeight) height = parentHeight;
           if (x === null) {
             x = (parentWidth - width) / 2;
-          } else if (x < 0) x = 0;
-          else if (x + width > parentWidth) x = parentWidth - width;
+          }
           if (y === null) {
             y = (parentHeight - height) / 2;
-          } else if (y < 0) y = 0;
-          else if (y + height > parentHeight) y = parentHeight - height;
+          }
           clientWidth = width;
           clientHeight = height - this.state.titleSize;
 

--- a/src/JSWindow/index.tsx
+++ b/src/JSWindow/index.tsx
@@ -23,6 +23,7 @@ export interface WindowProps {
   minScale?: number;
   maxScale?: number;
   moveable?: boolean;
+  workspace?: boolean;
   borderSize?: number;
   titleSize?: number;
   title?: string;
@@ -102,6 +103,7 @@ export class JSWindow extends Component<WindowProps, State> {
     minScale: 0.1,
     maxScale: 10,
     moveable: false,
+    workspace: false,
     borderSize: 16,
     titleSize: 40,
     title: "",
@@ -170,6 +172,7 @@ export class JSWindow extends Component<WindowProps, State> {
       minScale: props.minScale!,
       maxScale: props.maxScale!,
       moveable: props.moveable!,
+      workspace: props.workspace!,
       borderSize: state.borderSize,
       title: props.title!,
       titleSize: state.titleSize,
@@ -823,6 +826,7 @@ export class JSWindow extends Component<WindowProps, State> {
   }
 
   private panBy(x: number, y: number) {
+    if (!this.props.workspace) return;
     this.setState((prevState) => ({ transformation: {
       ...prevState.transformation,
       translateX: prevState.transformation.translateX + x,
@@ -831,6 +835,7 @@ export class JSWindow extends Component<WindowProps, State> {
   }
 
   private zoom(deltaScale: number, x: number, y: number) {
+    if (!this.props.workspace) return;
     const zoomNode: HTMLElement | null = this.zoomRef.current;
     if (!zoomNode) return;
 

--- a/src/JSWindow/index.tsx
+++ b/src/JSWindow/index.tsx
@@ -454,6 +454,7 @@ export class JSWindow extends Component<WindowProps, State> {
           Height={clientHeight}
           style={this.props.clientStyle!}
           onWheel={this.onWheel.bind(this)}
+          onMouseMove={this.onMouseMove.bind(this)}
         >
           <div ref={this.zoomRef} style={{
             transformOrigin: `${this.state.transformation.originX}px ${this.state.transformation.originY}px`,
@@ -807,6 +808,14 @@ export class JSWindow extends Component<WindowProps, State> {
     return [scale, newScale];
   }
 
+  private panBy(x: number, y: number) {
+    this.setState((prevState) => ({ transformation: {
+      ...prevState.transformation,
+      translateX: prevState.transformation.translateX + x,
+      translateY: prevState.transformation.translateY + y,
+    }}));
+  }
+
   private zoom(deltaScale: number, x: number, y: number) {
     const zoomNode: HTMLElement | null = this.zoomRef.current;
     if (!zoomNode) return;
@@ -837,6 +846,13 @@ export class JSWindow extends Component<WindowProps, State> {
     const e: any = evt.nativeEvent;
     if ((e.ctrlKey === true || e.altKey === true) && e.deltaY) {
       this.zoom(-Math.sign(e.deltaY), e.pageX, e.pageY);
+    }
+  }
+  private onMouseMove(evt: React.MouseEvent) {
+    const e: any = evt.nativeEvent;
+    if (e.shiftKey === true) {
+      this.panBy(e.movementX, e.movementY);
+      evt.stopPropagation();
     }
   }
 }

--- a/src/JSWindow/index.tsx
+++ b/src/JSWindow/index.tsx
@@ -1,7 +1,7 @@
 import ResizeObserver from "resize-observer-polyfill";
 import React, { ReactNode, Component, createRef } from "react";
 import { Manager, MovePoint,MEvent } from "@jswf/manager";
-import { Clinet } from "./parts/Client";
+import { Client } from "./parts/Client";
 import { Title } from "./parts/Title";
 import { Root } from "./JSWindow.style";
 import { Border, borders } from "./parts/Border";
@@ -420,7 +420,7 @@ export class JSWindow extends Component<WindowProps, State> {
               onMouseDown={this.onFrame.bind(this)}
             />
           ))}
-        <Clinet
+        <Client
           id="CLIENT"
           ref={this.clientRef}
           TitleSize={this.state.titleSize}
@@ -429,7 +429,7 @@ export class JSWindow extends Component<WindowProps, State> {
           style={this.props.clientStyle!}
         >
           {this.props.children}
-        </Clinet>
+        </Client>
       </Root>
     );
   }

--- a/src/JSWindow/parts/Client.ts
+++ b/src/JSWindow/parts/Client.ts
@@ -4,7 +4,7 @@ interface ClientState {
   TitleSize: number, Width: number, Height: number
 }
 
-export const Clinet = styled.div.attrs<ClientState>(p => ({
+export const Client = styled.div.attrs<ClientState>(p => ({
   style: {
     top: p.TitleSize + "px",
     width: p.Width + "px",


### PR DESCRIPTION
- Click + scroll to zoom
- Shift + mouse move to pan
- Adds `workspace` property to JSWindow, which _must_ be `true` for zoom & pan to be enabled
- Fixes main bugs regarding zoom (drag & resize) - ignores bugs with maximizing windows, etc.